### PR TITLE
Jar execution based on origin master

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?> 
 <!-- Copyright (c) 2018,2019 by Dr. Jody Paul
      This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
      http://creativecommons.org/licenses/by-sa/4.0/ -->

--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,6 @@
   <property name="doc" location="doc"/>
   <property name="build.dir" location="build"/>
   <property name="classes.dir" location="${build.dir}/classes"/>
-  <property name="jar.dir" location="${build.dir}/jar"/>
   <property name="dist" location="dist"/>
   <property name="allreports" location="reports"/>
   <property name="stylecheck" location="${allreports}"/>
@@ -85,7 +84,7 @@
 
 
   <target name="all"
-          depends="clean, doc-private, checkstyle, coverage, pmd, cpd, format"
+          depends="clean, doc-private, checkstyle, coverage, pmd, cpd, format, run"
           description="clean, generate documentation, analyze source code, run unit tests, check test coverage"/>
 
   <target name="clean"
@@ -118,6 +117,7 @@
   <target name="test" description="run unit tests" depends="testClean, unitTest" />
 
   <target name="compile" depends="init">
+   <echo message="compiling..." />
     <mkdir dir="${classes.dir}"/>
     <javac destdir="${classes.dir}"
            classpathref="test.classpath"
@@ -129,8 +129,8 @@
   </target>
 
   <target name="jar" depends="compile">
-    <mkdir dir="${jar.dir}"/>
-    <jar destfile="${jar.dir}/${productname}.jar" basedir="${classes.dir}">
+   <echo message="jarring it up..." />
+    <jar destfile="${productname}.jar" basedir="${classes.dir}">
       <manifest>
         <attribute name="Main-Class" value="${mainclass}"/>
       </manifest>
@@ -138,7 +138,8 @@
   </target>
 
   <target name="run" depends="jar">
-    <java jar="${jar.dir}/${productname}.jar" fork="true"/>
+   <echo message="running..." />
+   <java jar="${productname}.jar" fork="true"/>
   </target>
 
   <target name="unitTest" depends="test.junit.launcher, test.console.launcher" />
@@ -456,6 +457,5 @@
             description="Run unit tests with JaCoCo instrumentation and format results"/>
 
   <!-- JaCoCo END -->
-
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?> 
 <!-- Copyright (c) 2018,2019 by Dr. Jody Paul
      This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
      http://creativecommons.org/licenses/by-sa/4.0/ -->
@@ -25,6 +24,7 @@
   <property name="doc" location="doc"/>
   <property name="build.dir" location="build"/>
   <property name="classes.dir" location="${build.dir}/classes"/>
+  <property name="jar.dir" location="${build.dir}/jar"/>
   <property name="dist" location="dist"/>
   <property name="allreports" location="reports"/>
   <property name="stylecheck" location="${allreports}"/>
@@ -84,7 +84,7 @@
 
 
   <target name="all"
-          depends="clean, doc-private, checkstyle, coverage, pmd, cpd, format, run"
+          depends="clean, doc-private, checkstyle, coverage, pmd, cpd, format"
           description="clean, generate documentation, analyze source code, run unit tests, check test coverage"/>
 
   <target name="clean"
@@ -117,7 +117,6 @@
   <target name="test" description="run unit tests" depends="testClean, unitTest" />
 
   <target name="compile" depends="init">
-   <echo message="compiling..." />
     <mkdir dir="${classes.dir}"/>
     <javac destdir="${classes.dir}"
            classpathref="test.classpath"
@@ -129,8 +128,8 @@
   </target>
 
   <target name="jar" depends="compile">
-   <echo message="jarring it up..." />
-    <jar destfile="${productname}.jar" basedir="${classes.dir}">
+   <mkdir dir="${jar.dir}"/>
+    <jar destfile="${jar.dir}/${productname}.jar" basedir="${classes.dir}">
       <manifest>
         <attribute name="Main-Class" value="${mainclass}"/>
       </manifest>
@@ -138,8 +137,7 @@
   </target>
 
   <target name="run" depends="jar">
-   <echo message="running..." />
-   <java jar="${productname}.jar" fork="true"/>
+   <java jar="${jar.dir}/${productname}.jar" fork="true"/>
   </target>
 
   <target name="unitTest" depends="test.junit.launcher, test.console.launcher" />

--- a/build.xml
+++ b/build.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (c) 2018,2019 by Dr. Jody Paul
      This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
      http://creativecommons.org/licenses/by-sa/4.0/ -->
@@ -127,17 +128,20 @@
     </javac>
   </target>
 
-  <target name="jar" depends="compile">
-   <mkdir dir="${jar.dir}"/>
+  <target name="jar" depends="compile" 
+          description="Creates a jar file for the main class">
+    <mkdir dir="${jar.dir}"/>
     <jar destfile="${jar.dir}/${productname}.jar" basedir="${classes.dir}">
       <manifest>
         <attribute name="Main-Class" value="${mainclass}"/>
       </manifest>
     </jar>
+    <echo message="Jar file has been created, and can be found at: ${jar.dir}/${productname}.jar" />
   </target>
 
-  <target name="run" depends="jar">
-   <java jar="${jar.dir}/${productname}.jar" fork="true"/>
+  <target name="run" depends="jar"
+          description="Runs the program">
+    <java jar="${jar.dir}/${productname}.jar" fork="true"/>
   </target>
 
   <target name="unitTest" depends="test.junit.launcher, test.console.launcher" />
@@ -455,5 +459,6 @@
             description="Run unit tests with JaCoCo instrumentation and format results"/>
 
   <!-- JaCoCo END -->
+
 
 </project>


### PR DESCRIPTION
I created a new pull request for the changes to build.xml file.  I had to create a new branch, because the old one was based off of the master of the fork, and not the master for the MetroCS.  This is why there was commits for the vision.md file inside the old pull request.  I have since closed that pull request and am replacing it with this one.  

This pull request addresses issue: #8 

Since the last commit,  I have reverted the changes requested.  I have ensured that both Jar and Run show up in with the -p argument.  I have also put in a output message showing the user where the Jar is created at.