### PR TITLE
Voter-only region constructor and tests  (#18)

### DIFF
--- a/src/swdmt/redistricting/Region.java
+++ b/src/swdmt/redistricting/Region.java
@@ -94,6 +94,23 @@ public class Region implements java.io.Serializable {
     }
 
     /**
+     * Creates a region defined by the specified set of voters.
+     * @param voterSet the set of voters
+     */
+    public Region(final Set<Voter> voterSet) {
+        this.locations = new TreeSet<>();
+        this.voters = new HashSet<>();
+        this.voterMap = new HashMap<>();
+
+        for (Voter v : voterSet) {
+            Location loc = v.location();
+            this.locations.add(loc);
+            this.voters.add(v);
+            this.voterMap.put(v.location(), v);
+        }
+    }
+
+    /**
      * Accesses the number of locations in this region.
      * @return the number of locations
      */

--- a/src/swdmt/redistricting/RegionTest.java
+++ b/src/swdmt/redistricting/RegionTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.core.Is.is;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import java.util.Set;
+import java.util.HashSet;
 /**
  * Tests for class Region.
  *
@@ -85,5 +87,29 @@ public class RegionTest {
             assertThat("Square region number of voters failed at size " + i * i,
                        (new Region(i * i)).numberOfVoters(), is(i * i));
         }
+    }
+
+    @Test(timeout = MAX_TIMEOUT)
+    public void votersOnlySquareRegionTest() {
+        int numVotersSquare = 4;
+        Set<Voter> voters = new HashSet<>();
+        for (int i = 0; i < numVotersSquare; i++) {
+            for (int k = 0; k < numVotersSquare; k++){
+                voters.add(new Voter(null, new Location(i, k)));
+            }
+        }
+        Region newRegion = new Region(voters);
+    }
+
+    @Test(timeout = MAX_TIMEOUT)
+    public void votersOnlyNotSquareRegionTest() {
+        int numVoters = 5;
+        Set<Voter> voters = new HashSet<>();
+        for (int i = 0; i < numVoters; i++) {
+            for (int k = 0; k < numVoters; k++) {
+                voters.add(new Voter(null, new Location(i, k)));
+            }
+        }
+        Region newRegion = new Region(voters);
     }
 }


### PR DESCRIPTION
Resolves #59 

New Region constructor and tests that takes in only a Voter set as a parameter.

**Regarding Additional Design Decisions**

- The Voter class throws an exception if location() is null - so no need to be handled by this constructor as well
- Multiple voters with same location should be a separate issue as it involves more than just this constructor