### PR TITLE
Added jacoco.exec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ dist/
 nbdist/
 nbactions.xml
 nb-configuration.xml
+jacoco.exec


### PR DESCRIPTION
Added jacoco.exec to .gitignore under the developer section. Addresses issue #73.

Test:
After building the program with ant, the jacoco.exec no longer appears when using the git status command.