### PR TITLE
updated build.xml file to throw zero errors for issue #40

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -17,7 +17,7 @@
                 name="colorpropertyevaluator"
                 classpath="lib/ant-colorizor.jar" />
   <propertyhelper>
-    <colorpropertyevaluator />
+    <colorpropertyevaluator/>
   </propertyhelper>
 
   <!-- Global properties -->
@@ -201,7 +201,7 @@
         <filename name="**/*.java"/>
         <exclude name="**/*Test.java"/>
       </fileset>
-      <link href="https://docs.oracle.com/javase/8/docs/api/" />
+      <link href="https://docs.oracle.com/javase/17/docs/api/" />
     </javadoc>
   </target>
 
@@ -215,7 +215,8 @@
       <fileset dir="${src.dir}" casesensitive="yes" defaultexcludes="yes">
         <filename name="**/*.java"/>
       </fileset>
-      <link href="https://docs.oracle.com/javase/8/docs/api/" />
+
+      <link href="https://docs.oracle.com/javase/17/docs/api/" />
     </javadoc>
   </target>
 


### PR DESCRIPTION
This change was tested with JDK 8, 11, 12, and 16.
It works with no errors or warnings in 8, 11
![Screenshot from 2021-11-09 14-50-38](https://user-images.githubusercontent.com/46757429/141010688-d91bd5fd-a5a0-4f7f-b6be-4dc4c87704b9.png)
 and 12.

In JDK 16 there is a redirect warning from the URL from https://docs.oracle.com/javase/17/docs/api/ to https://docs.oracle.com/en/java/javase/17/docs/api/. 

If you update URL from the JDK 16 redirect in the code it becomes no longer compatible with JDK 8, so we decided to leave it so the API continues to work with JDK 8, and allow JDK 16 to do the redirect.