### PR TITLE
Fixed javadoc error warning

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -201,7 +201,7 @@
         <filename name="**/*.java"/>
         <exclude name="**/*Test.java"/>
       </fileset>
-      <link href="https://docs.oracle.com/javase/8/docs/api/" />
+      <link href="https://docs.oracle.com/en/java/javase/11/docs/api/" />
     </javadoc>
   </target>
 
@@ -215,7 +215,7 @@
       <fileset dir="${src.dir}" casesensitive="yes" defaultexcludes="yes">
         <filename name="**/*.java"/>
       </fileset>
-      <link href="https://docs.oracle.com/javase/8/docs/api/" />
+      <link href="https://docs.oracle.com/en/java/javase/11/docs/api/" />
     </javadoc>
   </target>
 


### PR DESCRIPTION
This fixes the Javadoc error warning as described in issue #40. This changes the url referenced in line 204 and 218 to reference the Javadoc api to the one for Java 11. This works for Java 11, 15, and 17.