### PR TITLE
Update DistrictTest, LocationTest, and PartyTest to JUnit 5 Jupiter - addresses User Story #114

### DIFF
--- a/src/swdmt/redistricting/DistrictTest.java
+++ b/src/swdmt/redistricting/DistrictTest.java
@@ -1,8 +1,8 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import java.util.HashSet;
 /**

--- a/src/swdmt/redistricting/LocationTest.java
+++ b/src/swdmt/redistricting/LocationTest.java
@@ -1,11 +1,11 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for objects of type Location.

--- a/src/swdmt/redistricting/PartyTest.java
+++ b/src/swdmt/redistricting/PartyTest.java
@@ -1,8 +1,8 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 /**
  * Tests of Party enum.
  *


### PR DESCRIPTION
This updates DistrictTest.java, LocationTest.java, and PartyTest.java so that:
Build process does not invoke legacy JUnit 4 framework
All test classes and tests are consistent with JUnit 5

This doesn't solve the whole user story. 