### PR TITLE
Updated RendererTest to JUnit5

### DIFF
--- a/src/swdmt/redistricting/RendererTest.java
+++ b/src/swdmt/redistricting/RendererTest.java
@@ -2,8 +2,8 @@ package swdmt.redistricting;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.HashSet;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * The test class for Renderer.


### PR DESCRIPTION
I updated RendererTest to fully utilize JUnit5 instead of using legacy JUnit4 framework. This resolves issue #118.