### PR TITLE
RedistrictorTest.java updated to Junit5, #117

### DIFF
--- a/src/swdmt/redistricting/RedistrictorTest.java
+++ b/src/swdmt/redistricting/RedistrictorTest.java
@@ -1,16 +1,20 @@
 package swdmt.redistricting;
-import static org.junit.Assert.assertThat;
+import org.hamcrest.MatcherAssert;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.AnyOf.anyOf;
-import static org.junit.Assert.assertTrue;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.util.Set;
+
 /**
  * Tests for redistrictor.
  *
- * @author  Dr. Jody Paul
+ * @author Dr. Jody Paul
  * @version 20191006
  */
 public class RedistrictorTest {
@@ -25,7 +29,7 @@ public class RedistrictorTest {
      *
      * Called before every test case method.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
     }
 
@@ -34,13 +38,13 @@ public class RedistrictorTest {
      *
      * Called after every test case method.
      */
-    @After
+    @AfterEach
     public void tearDown() {
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void invalidRegionParameterConstructorTest() {
-        Redistrictor r = new Redistrictor(null);
+    @Test
+    public void invalidRegionParameterConstructorTest(){
+        assertThrows(IllegalArgumentException.class, () -> new Redistrictor(null));
     }
 
     @Test
@@ -49,24 +53,24 @@ public class RedistrictorTest {
         Set<District> districtSet;
         region = new Region();
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
-        assertThat(districtSet.iterator().next().size(), is(0));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(0));
         region = new Region(1);
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
-        assertThat(districtSet.iterator().next().size(), is(1));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(1));
         region = new Region(4);
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
-        assertThat(districtSet.iterator().next().size(), is(4));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(4));
         region = new Region(9);
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
-        assertThat(districtSet.iterator().next().size(), is(9));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(9));
         region = new Region(16);
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
-        assertThat(districtSet.iterator().next().size(), is(16));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(16));
     }
 
     /**
@@ -83,77 +87,78 @@ public class RedistrictorTest {
         Set<District> districtSet;
         region = new Region();
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
         assertTrue(locationsUnique(districtSet));
-        assertThat(districtSet.iterator().next().size(), is(0));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(0));
 
         region = new Region(1);
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
         assertTrue(locationsUnique(districtSet));
-        assertThat(districtSet.iterator().next().size(), is(1));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(1));
 
         region = new Region(4);
         districtSet = Redistrictor.generateDistricts(region, 2);
-        assertThat(districtSet.size(), is(2));
+        MatcherAssert.assertThat(districtSet.size(), is(2));
         assertTrue(locationsUnique(districtSet));
-        assertThat(districtSet.iterator().next().size(), is(2));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(2));
 
         region = new Region(9);
         districtSet = Redistrictor.generateDistricts(region, 1);
-        assertThat(districtSet.size(), is(1));
+        MatcherAssert.assertThat(districtSet.size(), is(1));
         assertTrue(locationsUnique(districtSet));
-        assertThat(districtSet.iterator().next().size(), is(9));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(9));
 
         districtSet = Redistrictor.generateDistricts(region, 3);
-        assertThat(districtSet.size(), is(3));
+        MatcherAssert.assertThat(districtSet.size(), is(3));
         assertTrue(locationsUnique(districtSet));
-        assertThat(districtSet.iterator().next().size(), is(3));
+        MatcherAssert.assertThat(districtSet.iterator().next().size(), is(3));
         for (District d : districtSet) {
-            assertThat(d.size(), is(3));
+            MatcherAssert.assertThat(d.size(), is(3));
         }
 
         districtSet = Redistrictor.generateDistricts(region, 2);
-        assertThat(districtSet.size(), is(2));
+        MatcherAssert.assertThat(districtSet.size(), is(2));
         assertTrue(locationsUnique(districtSet));
         for (District d : districtSet) {
-            assertThat(d.size(), anyOf(is(4), is(5)));
+            MatcherAssert.assertThat(d.size(), anyOf(is(4), is(5)));
         }
         int numLocations = 0;
         for (District d : districtSet) {
             numLocations += d.size();
         }
-        assertThat(numLocations, is(9));
+        MatcherAssert.assertThat(numLocations, is(9));
 
         districtSet = Redistrictor.generateDistricts(region, 4);
-        assertThat(districtSet.size(), is(4));
+        MatcherAssert.assertThat(districtSet.size(), is(4));
         assertTrue(locationsUnique(districtSet));
         for (District d : districtSet) {
-            assertThat(d.size(), anyOf(is(2), is(3)));
+            MatcherAssert.assertThat(d.size(), anyOf(is(2), is(3)));
         }
         numLocations = 0;
         for (District d : districtSet) {
             numLocations += d.size();
         }
-        assertThat(numLocations, is(9));
+        MatcherAssert.assertThat(numLocations, is(9));
 
         districtSet = Redistrictor.generateDistricts(region, 5);
-        assertThat(districtSet.size(), is(5));
+        MatcherAssert.assertThat(districtSet.size(), is(5));
         assertTrue(locationsUnique(districtSet));
         for (District d : districtSet) {
-            assertThat(d.size(), anyOf(is(1), is(2)));
+            MatcherAssert.assertThat(d.size(), anyOf(is(1), is(2)));
         }
         numLocations = 0;
         for (District d : districtSet) {
             numLocations += d.size();
         }
-        assertThat(numLocations, is(9));
+        MatcherAssert.assertThat(numLocations, is(9));
     }
 
     /**
      * Utility to verify that all locations in a collection
      * of districts are unique; that is, no two districts
      * contain the same location.
+     *
      * @param districts the districts to consider
      * @return true if all locations are unique; false otherwise
      */
@@ -180,14 +185,14 @@ public class RedistrictorTest {
         Region region;
         Set<District> districtSet;
         region = new Region();
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 1).size(), is(0));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 1).size(), is(0));
         region = new Region(1);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 1).size(), is(1));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(1));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(1));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 1).size(), is(1));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(1));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(1));
         region = new Region(4);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(1));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 9).size(), is(1));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(1));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 9).size(), is(1));
     }
 
     @Test
@@ -195,23 +200,23 @@ public class RedistrictorTest {
         Region region;
         Set<District> districtSet;
         region = new Region(4);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(4));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(4));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(4));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(4));
         region = new Region(9);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(12));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(22));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(28));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 8).size(), is(5));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(12));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(22));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(28));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 8).size(), is(5));
         region = new Region(16);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(24));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(52));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(89));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(24));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(52));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(89));
         region = new Region(25);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(40));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(94));
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(180));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(40));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 3).size(), is(94));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 4).size(), is(180));
         region = new Region(64);
-        assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(112));
+        MatcherAssert.assertThat(Redistrictor.allDistrictsOfSpecificSize(region, 2).size(), is(112));
     }
 
     /**
@@ -226,40 +231,40 @@ public class RedistrictorTest {
         region = new Region();
         districtSet = Redistrictor.generateDistricts(region, 1);
         for (District d : districtSet) {
-            assertTrue("Checking contiguity of district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Checking contiguity of district " + d);
         }
         region = new Region(1);
         districtSet = Redistrictor.generateDistricts(region, 1);
         for (District d : districtSet) {
-            assertTrue("Checking contiguity of district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Checking contiguity of district " + d);
         }
 
         region = new Region(4);
         districtSet = Redistrictor.generateDistricts(region, 2);
         for (District d : districtSet) {
-            assertTrue("Checking contiguity of district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Checking contiguity of district " + d);
         }
 
         region = new Region(9);
         districtSet = Redistrictor.generateDistricts(region, 1);
         for (District d : districtSet) {
-            assertTrue("Contiguity error for district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
         }
         districtSet = Redistrictor.generateDistricts(region, 2);
         for (District d : districtSet) {
-            assertTrue("Contiguity error for district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
         }
         districtSet = Redistrictor.generateDistricts(region, 3);
         for (District d : districtSet) {
-            assertTrue("Contiguity error for district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
         }
         districtSet = Redistrictor.generateDistricts(region, 4);
         for (District d : districtSet) {
-            assertTrue("Contiguity error for district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
         }
         districtSet = Redistrictor.generateDistricts(region, 5);
         for (District d : districtSet) {
-            assertTrue("Contiguity error for district " + d, d.contiguityValid());
+            assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
         }
     }
 }


### PR DESCRIPTION
Now uses junit.jupiter.api with no legacy imports. #117, #58 