### PR TITLE
Changed redistricting algorithm to be based on Location.isAdjacentTo()

### DIFF
--- a/src/swdmt/redistricting/Redistrictor.java
+++ b/src/swdmt/redistricting/Redistrictor.java
@@ -2,7 +2,9 @@ package swdmt.redistricting;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Iterator;
 /**
@@ -62,42 +64,18 @@ public final class Redistrictor implements java.io.Serializable {
     public static Set<District> generateDistricts(final Region theRegion,
                                                   final int numDistricts) {
         Set<District> districts = new HashSet<District>();
-        List<List<Location>> districtLocs = new ArrayList<List<Location>>();
-        int numberOfDistricts = (numDistricts < 1) ? 1 : numDistricts;
-        int minimumNumberOfVotersPerDistrict
-                = theRegion.numberOfVoters() / numDistricts;
-        int numberOfAugmentedDistricts
-                = theRegion.numberOfVoters() % numDistricts;
-        Iterator<Location> locit = theRegion.locations().iterator();
-
-        Location[] snakingLocations =
-          new Location[theRegion.locations().size()];
-        for (int i = 0; i < theRegion.locations().size(); i++) {
-          snakingLocations[i] = locit.next();
-        }
-
-        Arrays.sort(snakingLocations, new SnakingLocationComparer());
-
-        int currentLocation = 0;
-
-        // Create covering districts with the proper
-        // number of locations.
-        // TODO: Contiguity for non rectangluar districts
-        // are NOT yet considered.
-        for (int i = 0; i < numberOfDistricts; i++) {
-            List<Location> locList = new ArrayList<Location>();
-            for (int vi = 0; vi < minimumNumberOfVotersPerDistrict; vi++) {
-              locList.add(snakingLocations[currentLocation++]);
+        HashMap<Location, HashSet<Location>> graph = generateGraphFromRegion(theRegion);
+        HashSet<Location> graphMembers = new HashSet<Location>();
+        graphMembers.addAll(graph.keySet());
+        try {
+        	HashSet<HashSet<Location>> locationSet = recursiveRedistrict(graph, graphMembers, graph.keySet().size()/numDistricts, numDistricts);
+        	for (HashSet<Location> element: locationSet) {
+            	districts.add(new District(element));
             }
-            if (i < numberOfAugmentedDistricts) {
-              locList.add(snakingLocations[currentLocation++]);
-            }
-
-            districtLocs.add(new ArrayList<Location>(locList));
         }
-
-        for (List<Location> locs : districtLocs) {
-            districts.add(new District(locs));
+        catch (NoSuchElementException e){
+        	districts.add(new District());
+        	return districts;
         }
         return districts;
     }
@@ -107,11 +85,13 @@ public final class Redistrictor implements java.io.Serializable {
      * specified size from a given region.
      * If the region is smaller than the specified size,
      * then a single district is returned.
-     * Otherwise, a set is created that contains all 
-     * districts of the specified size.
+     * Otherwise, creates a set of all districts of
+     * approximately equal size; that is, each district's
+     * size is within ±1 of the district size parameter.
      * @param theRegion the region
      * @param districtSize the size of the districts
      * @return a set of all districts of the specified size
+     *     within a tolerance of ±1
      */
     public static Set<District> allDistrictsOfSpecificSize(
                                     final Region theRegion,
@@ -152,4 +132,194 @@ public final class Redistrictor implements java.io.Serializable {
                                     final int districtSize) {
         return allDistrictsOfSpecificSize(theRegion, districtSize).iterator();
     }
+    
+    /**
+     * Recursive implementation of a redistricting algorithm.
+     * <p>
+     * Uses a graph to represent connections between locations,
+     * thus any location which is connected to another is considered
+     * adjacent and a contiguous path can be made between them.
+     * <p>
+     * Attempts to find a valid district using the flood method
+     * and then will remove that district from the input graph
+     * and call itself again on the remaining graph until no locations
+     * remain and the desired number of districts has been found.
+     * @param inputGraph A map representing connections between locations
+     * @param inputSet A set which defines membership in the graph
+     * @param districtSize The desired size of the districts
+     * @param desiredDistricts The number of districts to be found
+     * @return A set of sets of contiguous locations
+     * @throws NoSuchElementException If no possible districtings can be found
+     */
+    private static HashSet<HashSet<Location>> recursiveRedistrict(final HashMap<Location, HashSet<Location>> inputGraph,
+    																Set<Location> inputSet, 
+    																final int districtSize, 
+    																final int desiredDistricts) 
+    																throws NoSuchElementException{
+    	if (inputSet.isEmpty() && desiredDistricts == 0) {
+    		return new HashSet<HashSet<Location>>();
+    	}
+    	if ((inputSet.isEmpty() && desiredDistricts != 0) || (desiredDistricts == 0 && !inputSet.isEmpty())) {
+    		throw new NoSuchElementException();
+    	}
+    	if (inputSet.size() > desiredDistricts * (districtSize + 1)) {
+    		throw new NoSuchElementException();
+    	}
+    	if (subDivideGraph(inputGraph, inputSet).size() > desiredDistricts) {
+    		throw new NoSuchElementException();
+    	}
+    	HashSet<Location> potentialDistrict = null;
+    	HashSet<Location> potentialStart = new HashSet<Location>();
+		potentialStart.addAll(inputSet);
+    	for (int sizeDifference = 0; sizeDifference < 2; sizeDifference++) {
+    		for (int differencePass = 0; differencePass < 2; differencePass++) {
+	    		for (Location startingLoc: potentialStart){
+	    			try {
+	    				if (differencePass == 0) {
+	    					potentialDistrict = flood(inputGraph, inputSet, startingLoc, districtSize + sizeDifference);
+	    				}
+	    				else {
+	    					if (districtSize - sizeDifference > 0) {
+	    						potentialDistrict = flood(inputGraph, inputSet, startingLoc, districtSize - sizeDifference);
+	    					}
+	    					else {
+	    						potentialDistrict = flood(inputGraph, inputSet, startingLoc, 1);
+	    					}
+	    				}
+    					inputSet.removeAll(potentialDistrict);
+    					try {
+	    					HashSet<HashSet<Location>> output = recursiveRedistrict(inputGraph, inputSet, districtSize, desiredDistricts - 1);
+	    					output.add(potentialDistrict);
+	    					return output;
+    					}
+    					catch (NoSuchElementException e) {
+    						inputSet.addAll(potentialDistrict);
+    					}
+	    			}
+	    			catch (NoSuchElementException f) {
+	    				continue;
+	    			}
+	    		}
+    		}
+    	}
+    	throw new NoSuchElementException();
+    }
+    	
+    
+    /**
+     * Creates a graph out of a given region,
+     * using locations as vertices and connecting
+     * locations to any other location for which
+     * Location.isAdjacentTo is true.
+     * <p>
+     * Returns the graph in the form of a HashMap with locations
+     * as keys and the set of locations they are connected to
+     * as values.
+     * @TODO Implement functionality as described
+     * @param input The region to generate a graph from.
+     * @return A HashMap of locations, with values of the locations 
+     *         they are connected to.
+     */
+    private static HashMap<Location, HashSet<Location>> generateGraphFromRegion(final Region input){
+        HashMap<Location, HashSet<Location>> map = new HashMap<>();
+        for (Location locA : input.locations()) {
+            HashSet<Location> edges = new HashSet<Location>();
+            for (Location locB: input.locations()) {
+                if(locA.isAdjacentTo(locB)) {
+                    edges.add(locB);
+                }
+            }
+            map.put(locA,edges);
+        }
+    	return map;
+    }
+    
+    /**
+     * Returns a set of all contiguous sets of locations
+     * contained within a given graph. Consequently, if
+     * the entire graph is contiguous the returned set
+     * will only have one element, which is the set of
+     * all locations in the graph.
+     * <p>
+     * In practice, inputSet represents a graph with the
+     * same connections as specified in inputGraph, except
+     * only connections that connect locations within
+     * inputSet are considered valid.
+     * @TODO Consider faster way to assign remaining set
+     * @param inputGraph The overall graph of which inputSet represents a subgraph
+     * @param inputSet The set of locations which defines a subgraph of inputGraph
+     * @return A set containing all contiguous sets of locations within 
+     *         the graph represented by inputSet.
+     */
+    private static HashSet<HashSet<Location>> subDivideGraph(
+    									final HashMap<Location, HashSet<Location>> inputGraph,
+    									final Set<Location> inputSet){
+    	if (inputSet.isEmpty()) {
+    		return new HashSet<HashSet<Location>>();
+    	}
+    	Location start = inputSet.iterator().next();
+    	HashSet<Location> searched = new HashSet<Location>();
+    	HashSet<Location> searchList = new HashSet<Location>();
+    	searched.add(start);
+    	searchList.add(start);
+    	while (!searchList.isEmpty()) {
+    		Location pointer = searchList.iterator().next();
+			for (Location connection: inputGraph.get(pointer)) {
+				if (!(searched.contains(connection)) && inputSet.contains(connection)) {
+					searched.add(connection);
+					searchList.add(connection);
+				}
+			}
+    		searchList.remove(pointer);
+    	}
+    	HashSet<Location> remainingSet = new HashSet<Location>();
+    	remainingSet.addAll(inputSet);
+    	remainingSet.removeAll(searched);
+    	HashSet<HashSet<Location>> output = subDivideGraph(inputGraph, remainingSet);
+    	output.add(searched);
+    	return output;
+    }
+    
+    /**
+     * Finds a possible configuration of locations of a specified
+     * size by flooding out from an initial location until a specified
+     * size is reached. Uses a graph to define connections to navigate.
+     * Throws a NoSuchElementException if no flood pattern of a specific
+     * length can be found.
+     * @param inputGraph The map to use as reference for connections
+     * @param inputSet The set which defines membership of the graph
+     * @param start The location to start the search from
+     * @param size The desired size of the returned set
+     * @return A contiguous set of locations of a specified size
+     * @throws NoSuchElementException
+     */
+    private static HashSet<Location> flood(final HashMap<Location, HashSet<Location>> inputGraph,
+    										 final Set<Location> inputSet, 
+    										 final Location start, 
+    										 final int size) 
+    										 throws NoSuchElementException{
+    	if (size == 0) {
+    		return new HashSet<Location>();
+    	}
+    	ArrayList<Location> locationQueue = new ArrayList<Location>();
+    	HashSet<Location> outputSet = new HashSet<Location>();
+    	locationQueue.add(start);
+    	while(outputSet.size() < size && locationQueue.size() > 0) {
+    		Location currentLocation = locationQueue.remove(0);
+    		if (!outputSet.contains(currentLocation)) {
+    			outputSet.add(currentLocation);
+    			for (Location neighbor: inputGraph.get(currentLocation)) {
+    				if (!outputSet.contains(neighbor) && inputSet.contains(neighbor)) {
+    					locationQueue.add(neighbor);
+    				}
+    			}
+    		}
+    	}
+    	if (outputSet.size() < size) {
+    		throw new NoSuchElementException();
+    	}
+    	return outputSet;
+    }
 }
+
+

--- a/src/swdmt/redistricting/RedistrictorTest.java
+++ b/src/swdmt/redistricting/RedistrictorTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
 /**
  * Tests for redistrictor.
  *
@@ -262,8 +265,39 @@ public class RedistrictorTest {
         }
         districtSet = Redistrictor.generateDistricts(region, 5);
         for (District d : districtSet) {
-            assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
+        	assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
         }
     }
+    
+    /**
+     * Checks to see that the generateDistricts produces
+     * a valid set of districts for a region which should
+     * be redistrictable, but is not one contiguous region
+     * and has separate components on the same x and y levels.
+     */
+    @Test
+    public void generateDistrictsNonContiguousRegionTest() {
+    	Region region;
+    	Set<District> districtSet;
+    	Set<Voter> voterSet = new HashSet<Voter>();
+    	Location locationA = new Location(0,0);
+    	Location locationB = new Location(1,0);
+    	Location locationC = new Location(0,1);
+    	Location locationD = new Location(4,0);
+    	Location locationE = new Location(5,0);
+    	Location locationF = new Location(4,1);
+    	voterSet.add(new Voter(null, locationA));
+    	voterSet.add(new Voter(null, locationB));
+    	voterSet.add(new Voter(null, locationC));
+    	voterSet.add(new Voter(null, locationD));
+    	voterSet.add(new Voter(null, locationE));
+    	voterSet.add(new Voter(null, locationF));
+    	region = new Region(voterSet);
+    	districtSet = Redistrictor.generateDistricts(region, 2);
+    	for (District d : districtSet) {
+    		assertTrue(d.contiguityValid(), "Contiguity error for district " + d);
+    	}
+    }
+
 }
 


### PR DESCRIPTION
Finalized the redistricting algorithm in generateDistricts(), now the algorithm constructs a graph (HashMap<Location, Set<Location>>) based on Location.isAdjacentTo(), and recursively uses a method to flood (find a set of contiguous locations of a certain size) and then remove the discovered locations and call itself again. This approach will now be robust to different forms of adjacency and definitions of contiguity, and also works on non-contiguous rectangular graphs which the snaking districts algorithm previously failed on (a new unit test is included to ensure this behavior). Current algorithm passes all unit tests, and further work could be done on it to optimize it for better performance.

Solves issue #22 and begins to address issue #89 - since contiguity is now an implicit property of generated districts provided all adjacent locations contribute to contiguity.