### PR TITLE
Style change increases width of source code display in example

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+_site
+Gemfile.lock

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+gem "github-pages", "~> 219", group: :jekyll_plugins
+gem "webrick", "~> 1.7"

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,8 @@
+---
+---
+
+@import "jekyll-theme-tactile";
+
+code, pre {
+     width: 110%
+}


### PR DESCRIPTION
This addresses the concern raised about the horizontal scrolling of source code display in the HTML rendering of the [Create and Display Region](https://github.com/MetroCS/redistricting/blob/master/docs/examples/create_and_display_region.md) example:
- #155 

This PR also adds minimal support for local website development and testing using Jekyll (through added `.gitignore` and `Gemfile`).

Closes #155 