### PR TITLE
Flatten contents hierarchy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Goal: A Java utility package that supports the development of applications to in
 
 - ## [Project Description and Terminology](Redistricting.md)
 
-  - #### [API Documentation](https://metrocs.github.io/redistricting/api/index.html)
-  - #### Examples
+- ## [API Documentation](https://metrocs.github.io/redistricting/api/index.html)
+
+- ## Examples
     - [Create and Display a Region](docs/examples/create_and_display_region.md)
 
 - ## [Contributing](Contributing.md)
 
-  - #### [Development Conventions](DevelopmentConventions.md)
+- ## [Development Conventions](DevelopmentConventions.md)
 
 
 ___


### PR DESCRIPTION
Address confusion due to formatting of bullet items, such as expressed in #193

Resolves #193
